### PR TITLE
Improve for javascript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Java 6+ compatible
 https://npmjs.com/package/any-ascii
 
 ```javascript
-import anyAscii from 'any-ascii';
+import {anyAscii} from 'any-ascii';
 
 const s = anyAscii('άνθρωποι');
 // anthropoi

--- a/impl/js/README.md
+++ b/impl/js/README.md
@@ -9,7 +9,7 @@ Converts Unicode characters to their best ASCII representation
 AnyAscii provides ASCII-only replacement strings for practically all Unicode characters. Text is converted character-by-character without considering the context. The mappings for each script are based on popular existing romanization systems. Symbolic characters are converted based on their meaning or appearance. All ASCII characters in the input are left unchanged, every other character is replaced with printable ASCII characters. Unknown characters and some known characters are replaced with an empty string and removed.
 
 ```javascript
-import anyAscii from 'any-ascii';
+import {anyAscii} from 'any-ascii';
 
 const s = anyAscii('άνθρωποι');
 // anthropoi

--- a/impl/js/any-ascii.d.ts
+++ b/impl/js/any-ascii.d.ts
@@ -1,4 +1,7 @@
 /**
  * Transliterates a Unicode string into ASCII.
+ * 
+ * @param {string} string
+ * @return {string}
  */
 export function anyAscii(string: string): string;

--- a/impl/js/any-ascii.d.ts
+++ b/impl/js/any-ascii.d.ts
@@ -1,4 +1,4 @@
 /**
  * Transliterates a Unicode string into ASCII.
  */
-export default function anyAscii(string: string): string;
+export function anyAscii(string: string): string;

--- a/impl/js/any-ascii.js
+++ b/impl/js/any-ascii.js
@@ -1,4 +1,4 @@
-import block from './block.js';
+const block =  require('./block.js');
 
 const blocks = {};
 
@@ -8,7 +8,7 @@ const blocks = {};
  * @param {string} string
  * @return {string}
  */
-export default function anyAscii(string) {
+function anyAscii(string) {
 	let result = '';
 	for (const c of string) {
 		const codePoint = c.codePointAt(0);
@@ -28,3 +28,5 @@ export default function anyAscii(string) {
 	}
 	return result;
 }
+
+exports.default = anyAscii;

--- a/impl/js/any-ascii.js
+++ b/impl/js/any-ascii.js
@@ -29,4 +29,4 @@ function anyAscii(string) {
 	return result;
 }
 
-exports.default = anyAscii;
+exports.anyAscii = anyAscii;

--- a/impl/js/package.json
+++ b/impl/js/package.json
@@ -11,5 +11,6 @@
 	"types": "./any-ascii.d.ts",
 	"scripts": {
 		"test": "node ./test.js"
-	}
+	},
+	"files": ["block.js", "any-ascii.js", "any-ascii.d.ts"]
 }

--- a/impl/js/package.json
+++ b/impl/js/package.json
@@ -7,12 +7,8 @@
 	"author": "Hunter WB (https://hunterwb.com)",
 	"repository": "anyascii/anyascii",
 	"keywords": ["unicode", "ascii", "transliteration", "utf8", "romanization", "slug", "emoji", "unidecode", "normalization"],
-	"type": "module",
-	"exports": "./any-ascii.js",
+	"main": "./any-ascii.js",
 	"types": "./any-ascii.d.ts",
-	"engines": {
-		"node": ">=12.20"
-	},
 	"scripts": {
 		"test": "node ./test.js"
 	}

--- a/impl/js/test.js
+++ b/impl/js/test.js
@@ -1,4 +1,4 @@
-import anyAscii from './any-ascii.js';
+const anyAscii = require('./any-ascii.js');
 
 function check(s, expected) {
 	const actual = anyAscii(s);

--- a/impl/js/test.js
+++ b/impl/js/test.js
@@ -1,4 +1,4 @@
-const anyAscii = require('./any-ascii.js');
+const {anyAscii} = require('./any-ascii.js');
 
 function check(s, expected) {
 	const actual = anyAscii(s);

--- a/src/main/java/com/anyascii/build/gen/Js.kt
+++ b/src/main/java/com/anyascii/build/gen/Js.kt
@@ -5,7 +5,7 @@ import java.nio.file.Path
 
 fun js(g: Generator) {
     Files.newBufferedWriter(Path.of("impl/js/block.js")).use { w ->
-        w.write("export default function block(blockNum) {\n")
+        w.write("function block(blockNum) {\n")
         w.write("switch (blockNum) {\n")
         for ((blockNum, block) in g.blocks) {
             val s = block.noAscii().joinToString("\t").replace("\\", "\\\\").replace("\"", "\\\"")
@@ -14,5 +14,6 @@ fun js(g: Generator) {
         w.write("}\n")
         w.write("return\"\"\n")
         w.write("}\n")
+        w.write("exports.default = block;\n")
     }
 }


### PR DESCRIPTION
- Support for `commonjs` instead of `ESM`, because `anyascii` only exports a single function. So support ESM has no benefit. 
- Support older version Node.js.
- Named export instead of the default export: Best for Typescript suggestion.
- Publish only relevant files to npm.

**Help me re-generate the `block.js`** 