### PR TITLE
Support both CommonJS and ESM on JS implementation

### DIFF
--- a/impl/js/any-ascii.js
+++ b/impl/js/any-ascii.js
@@ -1,4 +1,4 @@
-import block from './block.js';
+const block = require('./block.js');
 
 const blocks = {};
 
@@ -8,7 +8,7 @@ const blocks = {};
  * @param {string} string
  * @return {string}
  */
-export default function anyAscii(string) {
+module.exports = function anyAscii(string) {
 	let result = '';
 	for (const c of string) {
 		const codePoint = c.codePointAt(0);

--- a/impl/js/any-ascii.mjs
+++ b/impl/js/any-ascii.mjs
@@ -1,0 +1,4 @@
+import anyAscii from "./any-ascii.js";
+
+export { anyAscii };
+export default anyAscii;

--- a/impl/js/block.js
+++ b/impl/js/block.js
@@ -1,4 +1,4 @@
-export default function block(blockNum) {
+module.exports = function block(blockNum) {
 switch (blockNum) {
 case 0:return"																																																																																																																																																																 	!	c	L	$	Y	|	S	\"	(C)	a	<<	!		(R)	-	deg	+-	2	3	'	u	P	-	,	1	o	>>	1/4	1/2	3/4	?	A	A	A	A	A	A	Ae	C	E	E	E	E	I	I	I	I	D	N	O	O	O	O	O	*	O	U	U	U	U	Y	Th	ss	a	a	a	a	a	a	ae	c	e	e	e	e	i	i	i	i	d	n	o	o	o	o	o	/	o	u	u	u	u	y	th	y"
 case 1:return"A	a	A	a	A	a	C	c	C	c	C	c	C	c	D	d	D	d	E	e	E	e	E	e	E	e	E	e	G	g	G	g	G	g	G	g	H	h	H	h	I	i	I	i	I	i	I	i	I	i	IJ	ij	J	j	K	k	q	L	l	L	l	L	l	L	l	L	l	N	n	N	n	N	n	'n	Ng	ng	O	o	O	o	O	o	Oe	oe	R	r	R	r	R	r	S	s	S	s	S	s	S	s	T	t	T	t	T	t	U	u	U	u	U	u	U	u	U	u	U	u	W	w	Y	y	Y	Z	z	Z	z	Z	z	s	b	B	B	b	6	6	O	C	c	D	D	D	d	z	E	E	E	F	f	G	G	hw	I	I	K	k	l	l	W	N	n	O	O	o	Gh	gh	P	p	R	2	2	Sh	sh	t	T	t	T	U	u	U	V	Y	y	Z	z	Zh	`	`	zh	dz	5	5	ts	w	c	x	qc	q	DZ	Dz	dz	LJ	Lj	lj	NJ	Nj	nj	A	a	I	i	O	o	U	u	U	u	U	u	U	u	U	u	e	A	a	A	a	Ae	ae	G	g	G	g	K	k	O	o	O	o	Zh	zh	j	DZ	Dz	dz	G	g	Hw	W	N	n	A	a	Ae	ae	O	o"

--- a/impl/js/package.json
+++ b/impl/js/package.json
@@ -9,6 +9,10 @@
 	"keywords": ["unicode", "ascii", "transliteration", "utf8", "romanization", "slug", "emoji", "unidecode", "normalization"],
 	"type": "commonjs",
 	"main": "./any-ascii.js",
+	"exports": {
+		"import": "./any-ascii.mjs",
+		"require": "./any-ascii.js"
+	},
 	"types": "./any-ascii.d.ts",
 	"engines": {
 		"node": ">=12.20"

--- a/impl/js/package.json
+++ b/impl/js/package.json
@@ -7,8 +7,8 @@
 	"author": "Hunter WB (https://hunterwb.com)",
 	"repository": "anyascii/anyascii",
 	"keywords": ["unicode", "ascii", "transliteration", "utf8", "romanization", "slug", "emoji", "unidecode", "normalization"],
-	"type": "module",
-	"exports": "./any-ascii.js",
+	"type": "commonjs",
+	"main": "./any-ascii.js",
 	"types": "./any-ascii.d.ts",
 	"engines": {
 		"node": ">=12.20"

--- a/impl/js/test.js
+++ b/impl/js/test.js
@@ -1,80 +1,91 @@
-const anyAscii = require('./any-ascii.js');
+// Wrap in async IIFE so we can use await for cleaner code.
+(async () => {
+	// Use package name instead of paths to verify that package.json "imports" section is set up correctly.
+	const mods = {
+		cjs: require('any-ascii'),
+		esmDefault: (await import('any-ascii')).default,
+		esmAnyAscii: (await import('any-ascii')).anyAscii,
+	};
 
-function check(s, expected) {
-	const actual = anyAscii(s);
-	if (actual !== expected) {
-		throw new Error(actual + " !== " + expected);
+	// Run tests for each require/import method.
+	for (const modName in mods) {
+		const check = (s, expected) => {
+			const actual = mods[modName](s);
+			if (actual !== expected) {
+				throw new Error(`[${modName}] ${actual} !== ${expected}`);
+			}
+		}
+
+		check("", "");
+		check("\u0000\u0001\t\n\u001f ~\u007f", "\u0000\u0001\t\n\u001f ~\u007f");
+		check("sample", "sample");
+
+		check("\u{0080}", "");
+		check("\u{00ff}", "y");
+		check("\u{e000}", "");
+		check("\u{ffff}", "");
+		check("\u{e0020}", " ");
+		check("\u{e007e}", "~");
+		check("\u{f0000}", "");
+		check("\u{f0001}", "");
+		check("\u{10ffff}", "");
+
+		check("René François Lacôte", "Rene Francois Lacote");
+		check("Blöße", "Blosse");
+		check("Trần Hưng Đạo", "Tran Hung Dao");
+		check("Nærøy", "Naeroy");
+		check("Φειδιππίδης", "Feidippidis");
+		check("Δημήτρης Φωτόπουλος", "Dimitris Fotopoylos");
+		check("Борис Николаевич Ельцин", "Boris Nikolaevich El'tsin");
+		check("Володимир Горбулін", "Volodimir Gorbulin");
+		check("Търговище", "T'rgovishche");
+		check("深圳", "ShenZhen");
+		check("深水埗", "ShenShuiBu");
+		check("화성시", "HwaSeongSi");
+		check("華城市", "HuaChengShi");
+		check("さいたま", "saitama");
+		check("埼玉県", "QiYuXian");
+		check("ደብረ ዘይት", "debre zeyt");
+		check("ደቀምሓረ", "dek'emhare");
+		check("دمنهور", "dmnhwr");
+		check("Աբովյան", "Abovyan");
+		check("სამტრედია", "samt'redia");
+		check("אברהם הלוי פרנקל", "'vrhm hlvy frnkl");
+		check("⠠⠎⠁⠽⠀⠭⠀⠁⠛", "+say x ag");
+		check("ময়মনসিংহ", "mymnsimh");
+		check("ထန်တလန်", "thntln");
+		check("પોરબંદર", "porbmdr");
+		check("महासमुंद", "mhasmumd");
+		check("ಬೆಂಗಳೂರು", "bemgluru");
+		check("សៀមរាប", "siemrab");
+		check("ສະຫວັນນະເຂດ", "sahvannaekhd");
+		check("കളമശ്ശേരി", "klmsseri");
+		check("ଗଜପତି", "gjpti");
+		check("ਜਲੰਧਰ", "jlmdhr");
+		check("රත්නපුර", "rtnpur");
+		check("கன்னியாகுமரி", "knniyakumri");
+		check("శ్రీకాకుళం", "srikakulm");
+		check("สงขลา", "sngkhla");
+		check("👑 🌴", ":crown: :palm_tree:");
+		check("☆ ♯ ♰ ⚄ ⛌", "* # + 5 X");
+		check("№ ℳ ⅋ ⅍", "No M & A/S");
+
+		check("トヨタ", "toyota");
+		check("ߞߐߣߊߞߙߌ߫", "konakri");
+		check("𐬰𐬀𐬭𐬀𐬚𐬎𐬱𐬙𐬭𐬀", "zarathushtra");
+		check("ⵜⵉⴼⵉⵏⴰⵖ", "tifinagh");
+		check("𐍅𐌿𐌻𐍆𐌹𐌻𐌰", "wulfila");
+		check("ދިވެހި", "dhivehi");
+		check("ᨅᨔ ᨕᨘᨁᨗ", "bs ugi");
+		check("ϯⲙⲓⲛϩⲱⲣ", "timinhor");
+		check("𐐜 𐐢𐐮𐐻𐑊 𐐝𐐻𐐪𐑉", "Dh Litl Star");
+		check("ꁌꐭꑤ", "pujjytxiep");
+		check("ⰳⰾⰰⰳⱁⰾⰹⱌⰰ", "glagolica");
+		check("ᏎᏉᏯ", "SeQuoYa");
+		check("ㄓㄨㄤ ㄅㄥ ㄒㄧㄠ", "zhuang beng xiao");
+		check("ꚩꚫꛑꚩꚳ ꚳ꛰ꛀꚧꚩꛂ", "ipareim m'shuoiya");
+		check("ᓀᐦᐃᔭᐍᐏᐣ", "nehiyawewin");
+		check("ᠤᠯᠠᠭᠠᠨᠴᠠᠪ", "ulaganqab");
+		check("𐑨𐑯𐑛𐑮𐑩𐑒𐑤𐑰𐑟 𐑯 𐑞 𐑤𐑲𐑩𐑯", "andr'kliiz n dh lai'n");
 	}
-}
-
-check("", "");
-check("\u0000\u0001\t\n\u001f ~\u007f", "\u0000\u0001\t\n\u001f ~\u007f");
-check("sample", "sample");
-
-check("\u{0080}", "");
-check("\u{00ff}", "y");
-check("\u{e000}", "");
-check("\u{ffff}", "");
-check("\u{e0020}", " ");
-check("\u{e007e}", "~");
-check("\u{f0000}", "");
-check("\u{f0001}", "");
-check("\u{10ffff}", "");
-
-check("René François Lacôte", "Rene Francois Lacote");
-check("Blöße", "Blosse");
-check("Trần Hưng Đạo", "Tran Hung Dao");
-check("Nærøy", "Naeroy");
-check("Φειδιππίδης", "Feidippidis");
-check("Δημήτρης Φωτόπουλος", "Dimitris Fotopoylos");
-check("Борис Николаевич Ельцин", "Boris Nikolaevich El'tsin");
-check("Володимир Горбулін", "Volodimir Gorbulin");
-check("Търговище", "T'rgovishche");
-check("深圳", "ShenZhen");
-check("深水埗", "ShenShuiBu");
-check("화성시", "HwaSeongSi");
-check("華城市", "HuaChengShi");
-check("さいたま", "saitama");
-check("埼玉県", "QiYuXian");
-check("ደብረ ዘይት", "debre zeyt");
-check("ደቀምሓረ", "dek'emhare");
-check("دمنهور", "dmnhwr");
-check("Աբովյան", "Abovyan");
-check("სამტრედია", "samt'redia");
-check("אברהם הלוי פרנקל", "'vrhm hlvy frnkl");
-check("⠠⠎⠁⠽⠀⠭⠀⠁⠛", "+say x ag");
-check("ময়মনসিংহ", "mymnsimh");
-check("ထန်တလန်", "thntln");
-check("પોરબંદર", "porbmdr");
-check("महासमुंद", "mhasmumd");
-check("ಬೆಂಗಳೂರು", "bemgluru");
-check("សៀមរាប", "siemrab");
-check("ສະຫວັນນະເຂດ", "sahvannaekhd");
-check("കളമശ്ശേരി", "klmsseri");
-check("ଗଜପତି", "gjpti");
-check("ਜਲੰਧਰ", "jlmdhr");
-check("රත්නපුර", "rtnpur");
-check("கன்னியாகுமரி", "knniyakumri");
-check("శ్రీకాకుళం", "srikakulm");
-check("สงขลา", "sngkhla");
-check("👑 🌴", ":crown: :palm_tree:");
-check("☆ ♯ ♰ ⚄ ⛌", "* # + 5 X");
-check("№ ℳ ⅋ ⅍", "No M & A/S");
-
-check("トヨタ", "toyota");
-check("ߞߐߣߊߞߙߌ߫", "konakri");
-check("𐬰𐬀𐬭𐬀𐬚𐬎𐬱𐬙𐬭𐬀", "zarathushtra");
-check("ⵜⵉⴼⵉⵏⴰⵖ", "tifinagh");
-check("𐍅𐌿𐌻𐍆𐌹𐌻𐌰", "wulfila");
-check("ދިވެހި", "dhivehi");
-check("ᨅᨔ ᨕᨘᨁᨗ", "bs ugi");
-check("ϯⲙⲓⲛϩⲱⲣ", "timinhor");
-check("𐐜 𐐢𐐮𐐻𐑊 𐐝𐐻𐐪𐑉", "Dh Litl Star");
-check("ꁌꐭꑤ", "pujjytxiep");
-check("ⰳⰾⰰⰳⱁⰾⰹⱌⰰ", "glagolica");
-check("ᏎᏉᏯ", "SeQuoYa");
-check("ㄓㄨㄤ ㄅㄥ ㄒㄧㄠ", "zhuang beng xiao");
-check("ꚩꚫꛑꚩꚳ ꚳ꛰ꛀꚧꚩꛂ", "ipareim m'shuoiya");
-check("ᓀᐦᐃᔭᐍᐏᐣ", "nehiyawewin");
-check("ᠤᠯᠠᠭᠠᠨᠴᠠᠪ", "ulaganqab");
-check("𐑨𐑯𐑛𐑮𐑩𐑒𐑤𐑰𐑟 𐑯 𐑞 𐑤𐑲𐑩𐑯", "andr'kliiz n dh lai'n");
+})();

--- a/impl/js/test.js
+++ b/impl/js/test.js
@@ -1,4 +1,4 @@
-import anyAscii from './any-ascii.js';
+const anyAscii = require('./any-ascii.js');
 
 function check(s, expected) {
 	const actual = anyAscii(s);

--- a/src/main/java/com/anyascii/build/gen/Js.kt
+++ b/src/main/java/com/anyascii/build/gen/Js.kt
@@ -5,7 +5,7 @@ import kotlin.io.path.bufferedWriter
 
 fun js(g: Generator) {
     Path.of("impl/js/block.js").bufferedWriter().use { w ->
-        w.write("export default function block(blockNum) {\n")
+        w.write("module.exports = function block(blockNum) {\n")
         w.write("switch (blockNum) {\n")
         for ((blockNum, block) in g.blocks) {
             val s = block.noAscii().joinToString("\t").replace("\\", "\\\\").replace("\"", "\\\"")


### PR DESCRIPTION
Many of us are still stuck using CommonJS due to circumstances outside of our control. The changes in this pull request will allow users of the JavaScript implementation to utilize either the CommonJS ("require") syntax or the ESM ("import") syntax.

In addition, tests were updated to include both syntaxes.

Resolves issue #10 